### PR TITLE
unique LoginSecure to each domain

### DIFF
--- a/steampy/login.py
+++ b/steampy/login.py
@@ -55,10 +55,16 @@ class LoginExecutor:
     def set_sessionid_cookies(self):
         community_domain = SteamUrl.COMMUNITY_URL[8:]
         store_domain = SteamUrl.STORE_URL[8:]
+        community_cookie_dic = self.session.cookies.get_dict(domain = community_domain)
+        store_cookie_dic = self.session.cookies.get_dict(domain = store_domain)
         for name in ['steamLoginSecure', 'sessionid', 'steamRefresh_steam', 'steamCountry']:
             cookie = self.session.cookies.get_dict()[name]
-            community_cookie = self._create_cookie(name, cookie, community_domain)
-            store_cookie = self._create_cookie(name, cookie, store_domain)
+            if name == 'steamLoginSecure':
+                community_cookie = self._create_cookie(name, community_cookie_dic['steamLoginSecure'], community_domain)
+                store_cookie = self._create_cookie(name, store_cookie_dic['steamLoginSecure'], store_domain)
+            else:
+                community_cookie = self._create_cookie(name, cookie, community_domain)
+                store_cookie = self._create_cookie(name, cookie, store_domain)
             self.session.cookies.set(**community_cookie)
             self.session.cookies.set(**store_cookie)
 


### PR DESCRIPTION
修复steam登录问题，将LoginSecure按照不同域名分别保存，方案来源：https://github.com/bukson/steampy/pull/344